### PR TITLE
DB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
 | address            | string     | null: false                    |
 | building           | string     |                                |
 | tel                | string     | null: false                    |
+| history            | references | null: false, foreign_key: true |
 
 ### Association
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,15 @@
 | nickname           | string  | null: false               |
 | email              | string  | null: false, unique: true |
 | encrypted_password | string  | null: false               |
-| name               | string  | null: false               |
-| name_kana          | string  | null: false               |
-| birthday_year_id   | integer | null: false               |
-| birthday_month_id  | integer | null: false               |
-| birthday_day_id    | integer | null: false               |
+| last_name          | string  | null: false               |
+| first_name         | string  | null: false               |
+| last_name_kana     | string  | null: false               |
+| first_name_kana    | string  | null: false               |
+| birthday           | date    | null: false               |
 
 ### Association
 
 - has_many :items
-- has_many :addresses
 - has_many :histories
 - has_many :comments
 
@@ -39,9 +38,8 @@
 
 ### Association
 
-- belongs_to :users
-- has_one :histories
-- has_many :comments
+- belongs_to :user
+- has_one :history
 
 
 
@@ -51,11 +49,13 @@
 | ------------------ | ---------- | ------------------------------ |
 | user               | references | null: false, foreign_key: true |
 | item               | references | null: false, foreign_key: true |
+| address            | references | null: false,                   |
 
 ### Association
 
-- belongs_to :users
-- belongs_to :items
+- belongs_to :user
+- belongs_to :item
+- has_one :history
 
 
 
@@ -63,7 +63,6 @@
 
 | Column             | Type       | Options                        |
 | ------------------ | ---------- | ------------------------------ |
-| user               | references | null: false, foreign_key: true |
 | post_code          | strings    | null: false                    |
 | city_id            | integer    | null: false                    |
 | municipalities     | strings    | null: false                    |
@@ -73,19 +72,5 @@
 
 ### Association
 
-- belongs_to :items
-- belongs_to :users 
-
-
-
-## comments テーブル
-
-| Column             | Type       | Options                        |
-| ------------------ | ---------- | ------------------------------ |
-| user               | references | null: false, foreign_key: true |
-| comment            | text       | null: false                    |
-
-### Association
-
-- belongs_to :user
-- belongs_to :items
+- belongs_to :item
+- belongs_to :history

--- a/README.md
+++ b/README.md
@@ -1,24 +1,80 @@
-# README
+# テーブル設計
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## users テーブル
 
-Things you may want to cover:
+| Column             | Type   | Options                   |
+| ------------------ | ------ | ------------------------- |
+| name               | string | null: false               |
+| email              | string | null: false, unique: true |
+| encrypted_password | string | null: false               |
 
-* Ruby version
 
-* System dependencies
+### Association
 
-* Configuration
+- has_many :items
+- has_one :buyer
+- has_many :addresses, through: :buyer
+- has_many :Purchase histories
 
-* Database creation
 
-* Database initialization
+## items テーブル
 
-* How to run the test suite
+| Column             | Type       | Options                        |
+| ------------------ | ---------- | ------------------------------ |
+| item_name          | string     | null: false                    |
+| price              | integer    | null: false                    |
+| category           | string     |                                |
+| overview           | text       |                                |
+| user               | references | null: false, foreign_key: true |
 
-* Services (job queues, cache servers, search engines, etc.)
+### Association
 
-* Deployment instructions
+- belongs_to :users
+- has_one :buyer
 
-* ...
+
+## buyers テーブル
+
+| Column             | Type       | Options                        |
+| ------------------ | ---------- | ------------------------------ |
+| user               | references | null: false, foreign_key: true |
+| item               | references | null: false, foreign_key: true |
+| address            | references | null: false, foreign_key: true |
+| date               | date       | null: false                    |
+
+### Association
+
+- belongs_to :users
+- belongs_to :items
+- has_many :addresses
+
+
+## addresses テーブル
+
+| Column             | Type       | Options                        |
+| ------------------ | ---------- | ------------------------------ |
+| user               | references | null: false, foreign_key: true |
+| post_code          | strings    | null: false                    |
+| prefectures        | strings    | null: false                    |
+| address            | strings    | null: false                    |
+| tel                | strings    | null: false                    |
+
+### Association
+
+- belongs_to :buyers
+- belongs_to :user, through: :buyers
+
+
+
+## Purchase histories テーブル （購入履歴）
+
+| Column             | Type       | Options                        |
+| ------------------ | ---------- | ------------------------------ |
+| user               | references | null: false, foreign_key: true |
+| item               | references | null: false, foreign_key: true |
+| buyer              | references | null: false, foreign_key: true |
+
+### Association
+
+- belongs_to :users
+- belongs_to :buyers

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | status_id          | integer    | null: false                    |
 | charge_id          | integer    | null: false                    |
 | city_id            | integer    | null: false                    |
-| day_id             | integer    | null: false                    |
+| delivery_id        | integer    | null: false                    |
 | price              | integer    | null: false                    |
 
 

--- a/README.md
+++ b/README.md
@@ -2,51 +2,61 @@
 
 ## users テーブル
 
-| Column             | Type   | Options                   |
-| ------------------ | ------ | ------------------------- |
-| name               | string | null: false               |
-| email              | string | null: false, unique: true |
-| encrypted_password | string | null: false               |
-
+| Column             | Type    | Options                   |
+| ------------------ | ------- | ------------------------- |
+| nickname           | string  | null: false               |
+| email              | string  | null: false, unique: true |
+| encrypted_password | string  | null: false               |
+| name               | string  | null: false               |
+| name_kana          | string  | null: false               |
+| birthday_year_id   | integer | null: false               |
+| birthday_month_id  | integer | null: false               |
+| birthday_day_id    | integer | null: false               |
 
 ### Association
 
 - has_many :items
-- has_one :buyer
-- has_many :addresses, through: :buyer
-- has_many :Purchase histories
+- has_many :addresses
+- has_many :histories
+- has_many :comments
+
 
 
 ## items テーブル
 
 | Column             | Type       | Options                        |
 | ------------------ | ---------- | ------------------------------ |
-| item_name          | string     | null: false                    |
-| price              | integer    | null: false                    |
-| category           | string     |                                |
-| overview           | text       |                                |
 | user               | references | null: false, foreign_key: true |
+| item_name          | string     | null: false                    |
+| overview           | text       | null: false                    |
+| category_id        | integer    | null: false                    |
+| status_id          | integer    | null: false                    |
+| charge_id          | integer    | null: false                    |
+| city_id            | integer    | null: false                    |
+| day_id             | integer    | null: false                    |
+| price              | integer    | null: false                    |
+
 
 ### Association
 
 - belongs_to :users
-- has_one :buyer
+- has_one :histories
+- has_many :comments
 
 
-## buyers テーブル
+
+## histories テーブル （購入履歴）
 
 | Column             | Type       | Options                        |
 | ------------------ | ---------- | ------------------------------ |
 | user               | references | null: false, foreign_key: true |
 | item               | references | null: false, foreign_key: true |
-| address            | references | null: false, foreign_key: true |
-| date               | date       | null: false                    |
 
 ### Association
 
 - belongs_to :users
 - belongs_to :items
-- has_many :addresses
+
 
 
 ## addresses テーブル
@@ -55,26 +65,27 @@
 | ------------------ | ---------- | ------------------------------ |
 | user               | references | null: false, foreign_key: true |
 | post_code          | strings    | null: false                    |
-| prefectures        | strings    | null: false                    |
+| city_id            | integer    | null: false                    |
+| municipalities     | strings    | null: false                    |
 | address            | strings    | null: false                    |
+| building           | strings    |                                |
 | tel                | strings    | null: false                    |
 
 ### Association
 
-- belongs_to :buyers
-- belongs_to :user, through: :buyers
+- belongs_to :items
+- belongs_to :users 
 
 
 
-## Purchase histories テーブル （購入履歴）
+## comments テーブル
 
 | Column             | Type       | Options                        |
 | ------------------ | ---------- | ------------------------------ |
 | user               | references | null: false, foreign_key: true |
-| item               | references | null: false, foreign_key: true |
-| buyer              | references | null: false, foreign_key: true |
+| comment            | text       | null: false                    |
 
 ### Association
 
-- belongs_to :users
-- belongs_to :buyers
+- belongs_to :user
+- belongs_to :items

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 
 - has_many :items
 - has_many :histories
-- has_many :comments
 
 
 
@@ -49,13 +48,12 @@
 | ------------------ | ---------- | ------------------------------ |
 | user               | references | null: false, foreign_key: true |
 | item               | references | null: false, foreign_key: true |
-| address            | references | null: false,                   |
 
 ### Association
 
 - belongs_to :user
 - belongs_to :item
-- has_one :history
+- has_one :address
 
 
 
@@ -63,14 +61,13 @@
 
 | Column             | Type       | Options                        |
 | ------------------ | ---------- | ------------------------------ |
-| post_code          | strings    | null: false                    |
+| post_code          | string     | null: false                    |
 | city_id            | integer    | null: false                    |
-| municipalities     | strings    | null: false                    |
-| address            | strings    | null: false                    |
-| building           | strings    |                                |
-| tel                | strings    | null: false                    |
+| municipalities     | string     | null: false                    |
+| address            | string     | null: false                    |
+| building           | string     |                                |
+| tel                | string     | null: false                    |
 
 ### Association
 
-- belongs_to :item
 - belongs_to :history

--- a/furima_ER.dio
+++ b/furima_ER.dio
@@ -53,7 +53,7 @@
                 <mxCell id="20" value="addresses（発送先情報）" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
                     <mxGeometry x="97.5" y="680" width="150" height="20" as="geometry"/>
                 </mxCell>
-                <mxCell id="21" value="&lt;ul&gt;&lt;li&gt;user&lt;/li&gt;&lt;li&gt;post_code（郵便番号）&lt;/li&gt;&lt;li&gt;cuty（都道府県）&lt;/li&gt;&lt;li&gt;municipalities（市区町村）&lt;/li&gt;&lt;li&gt;address（住所）&lt;/li&gt;&lt;li&gt;building（建物名：任意）&lt;/li&gt;&lt;li&gt;tel&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                <mxCell id="21" value="&lt;ul&gt;&lt;li&gt;post_code（郵便番号）&lt;/li&gt;&lt;li&gt;cuty（都道府県）&lt;/li&gt;&lt;li&gt;municipalities（市区町村）&lt;/li&gt;&lt;li&gt;address（住所）&lt;/li&gt;&lt;li&gt;building（建物名：任意）&lt;/li&gt;&lt;li&gt;tel&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
                     <mxGeometry x="70" y="705" width="190" height="185" as="geometry"/>
                 </mxCell>
                 <mxCell id="35" style="edgeStyle=none;html=1;exitX=0;exitY=0;exitDx=0;exitDy=0;fontSize=20;startArrow=diamondThin;startFill=1;endArrow=diamondThin;endFill=1;" edge="1" parent="1" source="32">

--- a/furima_ER.dio
+++ b/furima_ER.dio
@@ -1,0 +1,97 @@
+<mxfile host="65bd71144e">
+    <diagram id="fYaa-EfK72oNWuLgfd2z" name="ページ1">
+        <mxGraphModel dx="829" dy="759" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="16" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=-0.015;entryY=0.392;entryDx=0;entryDy=0;entryPerimeter=0;startArrow=ERone;startFill=0;endArrow=ERmany;endFill=0;" edge="1" parent="1" source="2" target="13">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="2" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="170" y="400" width="240" height="160" as="geometry"/>
+                </mxCell>
+                <mxCell id="3" value="users" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="260" y="410" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="24" style="edgeStyle=none;html=1;exitX=0;exitY=0.75;exitDx=0;exitDy=0;entryX=0.75;entryY=0;entryDx=0;entryDy=0;startArrow=ERone;startFill=0;endArrow=ERone;endFill=0;" edge="1" parent="1" source="5" target="15">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="5" value="" style="whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="560" y="400" width="240" height="250" as="geometry"/>
+                </mxCell>
+                <mxCell id="6" value="items（商品出品）" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="620" y="410" width="120" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="13" value="&lt;ul&gt;&lt;li&gt;item_name&lt;/li&gt;&lt;li&gt;user （出品者）&lt;/li&gt;&lt;li&gt;price&lt;/li&gt;&lt;li&gt;category&lt;/li&gt;&lt;li&gt;overview（商品説明）&lt;/li&gt;&lt;li&gt;image（商品画像）&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                    <mxGeometry x="560" y="430" width="240" height="220" as="geometry"/>
+                </mxCell>
+                <mxCell id="23" style="edgeStyle=none;html=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0.468;entryY=-0.029;entryDx=0;entryDy=0;entryPerimeter=0;startArrow=ERone;startFill=0;endArrow=ERone;endFill=0;" edge="1" parent="1" source="14" target="15">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="14" value="&lt;ul&gt;&lt;li&gt;name&lt;/li&gt;&lt;li&gt;email&lt;/li&gt;&lt;li&gt;password&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                    <mxGeometry x="170" y="430" width="230" height="130" as="geometry"/>
+                </mxCell>
+                <mxCell id="15" value="" style="shape=ext;double=1;rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="220" y="680" width="260" height="150" as="geometry"/>
+                </mxCell>
+                <mxCell id="17" value="buyers（商品購入）" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="290" y="690" width="120" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="22" style="edgeStyle=none;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;startArrow=ERone;startFill=0;endArrow=ERmany;endFill=0;" edge="1" parent="1" source="18" target="19">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="39" style="edgeStyle=none;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=20;startArrow=ERone;startFill=0;endArrow=ERone;endFill=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="18" target="41">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="70" y="770" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="18" value="&lt;ul&gt;&lt;li&gt;user&lt;/li&gt;&lt;li&gt;item_name&lt;/li&gt;&lt;li&gt;addresses&lt;/li&gt;&lt;li&gt;date（購入日）&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                    <mxGeometry x="220" y="710" width="260" height="120" as="geometry"/>
+                </mxCell>
+                <mxCell id="19" value="" style="shape=ext;double=1;rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="220" y="870" width="260" height="180" as="geometry"/>
+                </mxCell>
+                <mxCell id="20" value="addresses（発送先情報）" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="275" y="880" width="150" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="21" value="&lt;ul&gt;&lt;li&gt;user&lt;/li&gt;&lt;li&gt;post_code（郵便番号）&lt;/li&gt;&lt;li&gt;prefectures（都道府県）&lt;/li&gt;&lt;li&gt;address（住所）&lt;/li&gt;&lt;li&gt;tel&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                    <mxGeometry x="225" y="900" width="255" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="25" value="" style="shape=ext;double=1;rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="380" y="160" width="290" height="160" as="geometry"/>
+                </mxCell>
+                <mxCell id="26" value="Purchase histories（購入履歴）" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="430" y="170" width="190" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="30" style="edgeStyle=none;html=1;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=0.75;entryY=0;entryDx=0;entryDy=0;startArrow=ERmany;startFill=0;endArrow=ERone;endFill=0;" edge="1" parent="1" source="28" target="2">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="38" style="edgeStyle=none;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=20;startArrow=ERone;startFill=0;endArrow=ERone;endFill=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="28" target="41">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="70" y="259.66666666666663" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="28" value="&lt;ul&gt;&lt;li&gt;user（購入者）&lt;/li&gt;&lt;li&gt;date&lt;/li&gt;&lt;li&gt;item&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                    <mxGeometry x="380" y="200" width="290" height="120" as="geometry"/>
+                </mxCell>
+                <mxCell id="35" style="edgeStyle=none;html=1;exitX=0;exitY=0;exitDx=0;exitDy=0;fontSize=20;startArrow=diamondThin;startFill=1;endArrow=diamondThin;endFill=1;" edge="1" parent="1" source="32">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="500" y="630" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="32" value="" style="ellipse;shape=doubleEllipse;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="550" y="710" width="220" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="33" value="Pay.jp（決算購入）" style="text;strokeColor=none;fillColor=none;html=1;fontSize=20;fontStyle=1;verticalAlign=middle;align=center;" vertex="1" parent="1">
+                    <mxGeometry x="650" y="745" width="40" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="36" value="&lt;font style=&quot;font-size: 16px&quot;&gt;トークン&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fontSize=20;" vertex="1" parent="1">
+                    <mxGeometry x="550" y="675" width="80" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="41" value="" style="shape=crossbar;whiteSpace=wrap;html=1;rounded=1;direction=south;fontSize=20;" vertex="1" parent="1">
+                    <mxGeometry x="70" y="260" width="20" height="510" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/furima_ER.dio
+++ b/furima_ER.dio
@@ -24,7 +24,7 @@
                 <mxCell id="6" value="items（商品出品）" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
                     <mxGeometry x="540" y="401" width="120" height="20" as="geometry"/>
                 </mxCell>
-                <mxCell id="13" value="&lt;ul&gt;&lt;li&gt;item_name&lt;/li&gt;&lt;li&gt;user （出品者）&lt;/li&gt;&lt;li&gt;price&lt;/li&gt;&lt;li&gt;category&lt;/li&gt;&lt;li&gt;overview（商品説明）&lt;/li&gt;&lt;li&gt;status（商品の状態）&lt;/li&gt;&lt;li&gt;city（発送元地域）&lt;/li&gt;&lt;li&gt;cgage（配送手数料）&lt;/li&gt;&lt;li&gt;delivery（発送日数）&lt;/li&gt;&lt;li&gt;image（商品画像）&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                <mxCell id="13" value="&lt;ul&gt;&lt;li&gt;item_name&lt;/li&gt;&lt;li&gt;user （出品者）&lt;/li&gt;&lt;li&gt;price&lt;/li&gt;&lt;li&gt;category&lt;/li&gt;&lt;li&gt;overview_id（商品説明）&lt;/li&gt;&lt;li&gt;status_id（商品の状態）&lt;/li&gt;&lt;li&gt;city_id（発送元地域）&lt;/li&gt;&lt;li&gt;cgage_id（配送手数料）&lt;/li&gt;&lt;li&gt;delivery_id（発送日数）&lt;/li&gt;&lt;li&gt;image（商品画像）&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
                     <mxGeometry x="480" y="420" width="220" height="220" as="geometry"/>
                 </mxCell>
                 <mxCell id="47" style="edgeStyle=none;html=1;exitX=1;exitY=0.75;exitDx=0;exitDy=0;fontSize=20;startArrow=ERone;startFill=0;endArrow=ERmany;endFill=0;" edge="1" parent="1" source="14">
@@ -53,7 +53,7 @@
                 <mxCell id="20" value="addresses（発送先情報）" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
                     <mxGeometry x="97.5" y="680" width="150" height="20" as="geometry"/>
                 </mxCell>
-                <mxCell id="21" value="&lt;ul&gt;&lt;li&gt;post_code（郵便番号）&lt;/li&gt;&lt;li&gt;cuty（都道府県）&lt;/li&gt;&lt;li&gt;municipalities（市区町村）&lt;/li&gt;&lt;li&gt;address（住所）&lt;/li&gt;&lt;li&gt;building（建物名：任意）&lt;/li&gt;&lt;li&gt;tel&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                <mxCell id="21" value="&lt;ul&gt;&lt;li&gt;post_code（郵便番号）&lt;/li&gt;&lt;li&gt;cuty_id（都道府県）&lt;/li&gt;&lt;li&gt;municipalities（市区町村）&lt;/li&gt;&lt;li&gt;address（住所）&lt;/li&gt;&lt;li&gt;building（建物名：任意）&lt;/li&gt;&lt;li&gt;tel&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
                     <mxGeometry x="70" y="705" width="190" height="185" as="geometry"/>
                 </mxCell>
                 <mxCell id="35" style="edgeStyle=none;html=1;exitX=0;exitY=0;exitDx=0;exitDy=0;fontSize=20;startArrow=diamondThin;startFill=1;endArrow=diamondThin;endFill=1;" edge="1" parent="1" source="32">

--- a/furima_ER.dio
+++ b/furima_ER.dio
@@ -1,82 +1,69 @@
 <mxfile host="65bd71144e">
     <diagram id="fYaa-EfK72oNWuLgfd2z" name="ページ1">
-        <mxGraphModel dx="829" dy="759" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+        <mxGraphModel dx="998" dy="875" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
-                <mxCell id="16" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=-0.015;entryY=0.392;entryDx=0;entryDy=0;entryPerimeter=0;startArrow=ERone;startFill=0;endArrow=ERmany;endFill=0;" edge="1" parent="1" source="2" target="13">
+                <mxCell id="45" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;fontSize=20;startArrow=ERone;startFill=0;endArrow=ERmany;endFill=0;" edge="1" parent="1" source="2" target="5">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="54" style="edgeStyle=none;html=1;exitX=0.75;exitY=0;exitDx=0;exitDy=0;entryX=0.25;entryY=1;entryDx=0;entryDy=0;fontSize=13;startArrow=ERone;startFill=0;endArrow=ERmany;endFill=0;" edge="1" parent="1" source="2" target="50">
                     <mxGeometry relative="1" as="geometry"/>
                 </mxCell>
                 <mxCell id="2" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-                    <mxGeometry x="170" y="400" width="240" height="160" as="geometry"/>
+                    <mxGeometry x="190" y="400" width="130" height="240" as="geometry"/>
                 </mxCell>
                 <mxCell id="3" value="users" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
-                    <mxGeometry x="260" y="410" width="40" height="20" as="geometry"/>
+                    <mxGeometry x="235" y="400" width="40" height="20" as="geometry"/>
                 </mxCell>
-                <mxCell id="24" style="edgeStyle=none;html=1;exitX=0;exitY=0.75;exitDx=0;exitDy=0;entryX=0.75;entryY=0;entryDx=0;entryDy=0;startArrow=ERone;startFill=0;endArrow=ERone;endFill=0;" edge="1" parent="1" source="5" target="15">
-                    <mxGeometry relative="1" as="geometry"/>
+                <mxCell id="48" style="edgeStyle=none;html=1;exitX=0;exitY=0.75;exitDx=0;exitDy=0;fontSize=20;startArrow=ERone;startFill=0;endArrow=ERone;endFill=0;" edge="1" parent="1" source="5">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="420" y="670" as="targetPoint"/>
+                    </mxGeometry>
                 </mxCell>
                 <mxCell id="5" value="" style="whiteSpace=wrap;html=1;" vertex="1" parent="1">
-                    <mxGeometry x="560" y="400" width="240" height="250" as="geometry"/>
+                    <mxGeometry x="470" y="400" width="240" height="240" as="geometry"/>
                 </mxCell>
                 <mxCell id="6" value="items（商品出品）" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
-                    <mxGeometry x="620" y="410" width="120" height="20" as="geometry"/>
+                    <mxGeometry x="540" y="401" width="120" height="20" as="geometry"/>
                 </mxCell>
-                <mxCell id="13" value="&lt;ul&gt;&lt;li&gt;item_name&lt;/li&gt;&lt;li&gt;user （出品者）&lt;/li&gt;&lt;li&gt;price&lt;/li&gt;&lt;li&gt;category&lt;/li&gt;&lt;li&gt;overview（商品説明）&lt;/li&gt;&lt;li&gt;image（商品画像）&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
-                    <mxGeometry x="560" y="430" width="240" height="220" as="geometry"/>
+                <mxCell id="13" value="&lt;ul&gt;&lt;li&gt;item_name&lt;/li&gt;&lt;li&gt;user （出品者）&lt;/li&gt;&lt;li&gt;price&lt;/li&gt;&lt;li&gt;category&lt;/li&gt;&lt;li&gt;overview（商品説明）&lt;/li&gt;&lt;li&gt;status（商品の状態）&lt;/li&gt;&lt;li&gt;city（発送元地域）&lt;/li&gt;&lt;li&gt;cgage（配送手数料）&lt;/li&gt;&lt;li&gt;day（発送日数）&lt;/li&gt;&lt;li&gt;image（商品画像）&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                    <mxGeometry x="480" y="420" width="220" height="220" as="geometry"/>
                 </mxCell>
-                <mxCell id="23" style="edgeStyle=none;html=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0.468;entryY=-0.029;entryDx=0;entryDy=0;entryPerimeter=0;startArrow=ERone;startFill=0;endArrow=ERone;endFill=0;" edge="1" parent="1" source="14" target="15">
-                    <mxGeometry relative="1" as="geometry"/>
+                <mxCell id="47" style="edgeStyle=none;html=1;exitX=1;exitY=0.75;exitDx=0;exitDy=0;fontSize=20;startArrow=ERone;startFill=0;endArrow=ERmany;endFill=0;" edge="1" parent="1" source="14">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="370" y="670" as="targetPoint"/>
+                    </mxGeometry>
                 </mxCell>
-                <mxCell id="14" value="&lt;ul&gt;&lt;li&gt;name&lt;/li&gt;&lt;li&gt;email&lt;/li&gt;&lt;li&gt;password&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
-                    <mxGeometry x="170" y="430" width="230" height="130" as="geometry"/>
+                <mxCell id="49" style="edgeStyle=none;html=1;exitX=0;exitY=0.75;exitDx=0;exitDy=0;fontSize=20;startArrow=ERone;startFill=0;endArrow=ERmany;endFill=0;" edge="1" parent="1" source="14">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="140" y="670" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="14" value="&lt;ul&gt;&lt;li&gt;nickname&lt;/li&gt;&lt;li&gt;email&lt;/li&gt;&lt;li&gt;password&lt;/li&gt;&lt;li&gt;name&lt;/li&gt;&lt;li&gt;name_kana&lt;/li&gt;&lt;li&gt;birthday&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                    <mxGeometry x="190" y="430" width="130" height="200" as="geometry"/>
                 </mxCell>
                 <mxCell id="15" value="" style="shape=ext;double=1;rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-                    <mxGeometry x="220" y="680" width="260" height="150" as="geometry"/>
+                    <mxGeometry x="330" y="675" width="140" height="125" as="geometry"/>
                 </mxCell>
-                <mxCell id="17" value="buyers（商品購入）" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
-                    <mxGeometry x="290" y="690" width="120" height="20" as="geometry"/>
+                <mxCell id="17" value="histories" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="370" y="680" width="60" height="20" as="geometry"/>
                 </mxCell>
-                <mxCell id="22" style="edgeStyle=none;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;startArrow=ERone;startFill=0;endArrow=ERmany;endFill=0;" edge="1" parent="1" source="18" target="19">
-                    <mxGeometry relative="1" as="geometry"/>
-                </mxCell>
-                <mxCell id="39" style="edgeStyle=none;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=20;startArrow=ERone;startFill=0;endArrow=ERone;endFill=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="18" target="41">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="70" y="770" as="targetPoint"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="18" value="&lt;ul&gt;&lt;li&gt;user&lt;/li&gt;&lt;li&gt;item_name&lt;/li&gt;&lt;li&gt;addresses&lt;/li&gt;&lt;li&gt;date（購入日）&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
-                    <mxGeometry x="220" y="710" width="260" height="120" as="geometry"/>
+                <mxCell id="18" value="&lt;ul&gt;&lt;li&gt;users&lt;/li&gt;&lt;li&gt;items&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                    <mxGeometry x="340" y="700" width="120" height="90" as="geometry"/>
                 </mxCell>
                 <mxCell id="19" value="" style="shape=ext;double=1;rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-                    <mxGeometry x="220" y="870" width="260" height="180" as="geometry"/>
+                    <mxGeometry x="70" y="675" width="205" height="225" as="geometry"/>
                 </mxCell>
                 <mxCell id="20" value="addresses（発送先情報）" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
-                    <mxGeometry x="275" y="880" width="150" height="20" as="geometry"/>
+                    <mxGeometry x="97.5" y="680" width="150" height="20" as="geometry"/>
                 </mxCell>
-                <mxCell id="21" value="&lt;ul&gt;&lt;li&gt;user&lt;/li&gt;&lt;li&gt;post_code（郵便番号）&lt;/li&gt;&lt;li&gt;prefectures（都道府県）&lt;/li&gt;&lt;li&gt;address（住所）&lt;/li&gt;&lt;li&gt;tel&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
-                    <mxGeometry x="225" y="900" width="255" height="140" as="geometry"/>
-                </mxCell>
-                <mxCell id="25" value="" style="shape=ext;double=1;rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-                    <mxGeometry x="380" y="160" width="290" height="160" as="geometry"/>
-                </mxCell>
-                <mxCell id="26" value="Purchase histories（購入履歴）" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
-                    <mxGeometry x="430" y="170" width="190" height="20" as="geometry"/>
-                </mxCell>
-                <mxCell id="30" style="edgeStyle=none;html=1;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=0.75;entryY=0;entryDx=0;entryDy=0;startArrow=ERmany;startFill=0;endArrow=ERone;endFill=0;" edge="1" parent="1" source="28" target="2">
-                    <mxGeometry relative="1" as="geometry"/>
-                </mxCell>
-                <mxCell id="38" style="edgeStyle=none;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=20;startArrow=ERone;startFill=0;endArrow=ERone;endFill=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="28" target="41">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="70" y="259.66666666666663" as="targetPoint"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="28" value="&lt;ul&gt;&lt;li&gt;user（購入者）&lt;/li&gt;&lt;li&gt;date&lt;/li&gt;&lt;li&gt;item&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
-                    <mxGeometry x="380" y="200" width="290" height="120" as="geometry"/>
+                <mxCell id="21" value="&lt;ul&gt;&lt;li&gt;user&lt;/li&gt;&lt;li&gt;post_code（郵便番号）&lt;/li&gt;&lt;li&gt;cuty（都道府県）&lt;/li&gt;&lt;li&gt;municipalities（市区町村）&lt;/li&gt;&lt;li&gt;address（住所）&lt;/li&gt;&lt;li&gt;building（建物名：任意）&lt;/li&gt;&lt;li&gt;tel&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                    <mxGeometry x="70" y="705" width="190" height="185" as="geometry"/>
                 </mxCell>
                 <mxCell id="35" style="edgeStyle=none;html=1;exitX=0;exitY=0;exitDx=0;exitDy=0;fontSize=20;startArrow=diamondThin;startFill=1;endArrow=diamondThin;endFill=1;" edge="1" parent="1" source="32">
                     <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="500" y="630" as="targetPoint"/>
+                        <mxPoint x="450" y="640" as="targetPoint"/>
                     </mxGeometry>
                 </mxCell>
                 <mxCell id="32" value="" style="ellipse;shape=doubleEllipse;whiteSpace=wrap;html=1;" vertex="1" parent="1">
@@ -86,10 +73,19 @@
                     <mxGeometry x="650" y="745" width="40" height="40" as="geometry"/>
                 </mxCell>
                 <mxCell id="36" value="&lt;font style=&quot;font-size: 16px&quot;&gt;トークン&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fontSize=20;" vertex="1" parent="1">
-                    <mxGeometry x="550" y="675" width="80" height="30" as="geometry"/>
+                    <mxGeometry x="540" y="675" width="80" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="41" value="" style="shape=crossbar;whiteSpace=wrap;html=1;rounded=1;direction=south;fontSize=20;" vertex="1" parent="1">
-                    <mxGeometry x="70" y="260" width="20" height="510" as="geometry"/>
+                <mxCell id="55" style="edgeStyle=none;html=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0.25;entryY=0;entryDx=0;entryDy=0;fontSize=13;startArrow=ERmany;startFill=0;endArrow=ERone;endFill=0;" edge="1" parent="1" source="50" target="5">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="50" value="" style="rounded=0;whiteSpace=wrap;html=1;fontSize=20;" vertex="1" parent="1">
+                    <mxGeometry x="320" y="200" width="170" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="51" value="comments" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fontSize=13;" vertex="1" parent="1">
+                    <mxGeometry x="360" y="200" width="80" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="52" value="&lt;ul&gt;&lt;li&gt;user（閲覧者）&lt;/li&gt;&lt;li&gt;comment&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;fontSize=13;" vertex="1" parent="1">
+                    <mxGeometry x="320" y="220" width="170" height="70" as="geometry"/>
                 </mxCell>
             </root>
         </mxGraphModel>

--- a/furima_ER.dio
+++ b/furima_ER.dio
@@ -1,17 +1,14 @@
 <mxfile host="65bd71144e">
     <diagram id="fYaa-EfK72oNWuLgfd2z" name="ページ1">
-        <mxGraphModel dx="998" dy="875" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+        <mxGraphModel dx="1283" dy="875" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
                 <mxCell id="45" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;fontSize=20;startArrow=ERone;startFill=0;endArrow=ERmany;endFill=0;" edge="1" parent="1" source="2" target="5">
                     <mxGeometry relative="1" as="geometry"/>
                 </mxCell>
-                <mxCell id="54" style="edgeStyle=none;html=1;exitX=0.75;exitY=0;exitDx=0;exitDy=0;entryX=0.25;entryY=1;entryDx=0;entryDy=0;fontSize=13;startArrow=ERone;startFill=0;endArrow=ERmany;endFill=0;" edge="1" parent="1" source="2" target="50">
-                    <mxGeometry relative="1" as="geometry"/>
-                </mxCell>
                 <mxCell id="2" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-                    <mxGeometry x="190" y="400" width="130" height="240" as="geometry"/>
+                    <mxGeometry x="160" y="400" width="160" height="240" as="geometry"/>
                 </mxCell>
                 <mxCell id="3" value="users" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
                     <mxGeometry x="235" y="400" width="40" height="20" as="geometry"/>
@@ -35,13 +32,8 @@
                         <mxPoint x="370" y="670" as="targetPoint"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="49" style="edgeStyle=none;html=1;exitX=0;exitY=0.75;exitDx=0;exitDy=0;fontSize=20;startArrow=ERone;startFill=0;endArrow=ERmany;endFill=0;" edge="1" parent="1" source="14">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="140" y="670" as="targetPoint"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="14" value="&lt;ul&gt;&lt;li&gt;nickname&lt;/li&gt;&lt;li&gt;email&lt;/li&gt;&lt;li&gt;password&lt;/li&gt;&lt;li&gt;name&lt;/li&gt;&lt;li&gt;name_kana&lt;/li&gt;&lt;li&gt;birthday&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
-                    <mxGeometry x="190" y="430" width="130" height="200" as="geometry"/>
+                <mxCell id="14" value="&lt;ul&gt;&lt;li&gt;nickname&lt;/li&gt;&lt;li&gt;email&lt;/li&gt;&lt;li&gt;password&lt;/li&gt;&lt;li&gt;last_name&lt;/li&gt;&lt;li&gt;first_name&lt;/li&gt;&lt;li&gt;last_name_kana&lt;/li&gt;&lt;li&gt;first_name_kana&lt;/li&gt;&lt;li&gt;birthday&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                    <mxGeometry x="160" y="430" width="160" height="200" as="geometry"/>
                 </mxCell>
                 <mxCell id="15" value="" style="shape=ext;double=1;rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
                     <mxGeometry x="330" y="675" width="140" height="125" as="geometry"/>
@@ -49,8 +41,11 @@
                 <mxCell id="17" value="histories" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
                     <mxGeometry x="370" y="680" width="60" height="20" as="geometry"/>
                 </mxCell>
-                <mxCell id="18" value="&lt;ul&gt;&lt;li&gt;users&lt;/li&gt;&lt;li&gt;items&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                <mxCell id="18" value="&lt;ul&gt;&lt;li&gt;users&lt;/li&gt;&lt;li&gt;items&lt;/li&gt;&lt;li&gt;address&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
                     <mxGeometry x="340" y="700" width="120" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="57" style="edgeStyle=none;html=1;exitX=1;exitY=0.25;exitDx=0;exitDy=0;entryX=-0.014;entryY=0.425;entryDx=0;entryDy=0;entryPerimeter=0;fontSize=13;startArrow=ERone;startFill=0;endArrow=ERone;endFill=0;" edge="1" parent="1" source="19" target="15">
+                    <mxGeometry relative="1" as="geometry"/>
                 </mxCell>
                 <mxCell id="19" value="" style="shape=ext;double=1;rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
                     <mxGeometry x="70" y="675" width="205" height="225" as="geometry"/>
@@ -74,18 +69,6 @@
                 </mxCell>
                 <mxCell id="36" value="&lt;font style=&quot;font-size: 16px&quot;&gt;トークン&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fontSize=20;" vertex="1" parent="1">
                     <mxGeometry x="540" y="675" width="80" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="55" style="edgeStyle=none;html=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0.25;entryY=0;entryDx=0;entryDy=0;fontSize=13;startArrow=ERmany;startFill=0;endArrow=ERone;endFill=0;" edge="1" parent="1" source="50" target="5">
-                    <mxGeometry relative="1" as="geometry"/>
-                </mxCell>
-                <mxCell id="50" value="" style="rounded=0;whiteSpace=wrap;html=1;fontSize=20;" vertex="1" parent="1">
-                    <mxGeometry x="320" y="200" width="170" height="110" as="geometry"/>
-                </mxCell>
-                <mxCell id="51" value="comments" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fontSize=13;" vertex="1" parent="1">
-                    <mxGeometry x="360" y="200" width="80" height="20" as="geometry"/>
-                </mxCell>
-                <mxCell id="52" value="&lt;ul&gt;&lt;li&gt;user（閲覧者）&lt;/li&gt;&lt;li&gt;comment&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;fontSize=13;" vertex="1" parent="1">
-                    <mxGeometry x="320" y="220" width="170" height="70" as="geometry"/>
                 </mxCell>
             </root>
         </mxGraphModel>

--- a/furima_ER.dio
+++ b/furima_ER.dio
@@ -24,7 +24,7 @@
                 <mxCell id="6" value="items（商品出品）" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;" vertex="1" parent="1">
                     <mxGeometry x="540" y="401" width="120" height="20" as="geometry"/>
                 </mxCell>
-                <mxCell id="13" value="&lt;ul&gt;&lt;li&gt;item_name&lt;/li&gt;&lt;li&gt;user （出品者）&lt;/li&gt;&lt;li&gt;price&lt;/li&gt;&lt;li&gt;category&lt;/li&gt;&lt;li&gt;overview（商品説明）&lt;/li&gt;&lt;li&gt;status（商品の状態）&lt;/li&gt;&lt;li&gt;city（発送元地域）&lt;/li&gt;&lt;li&gt;cgage（配送手数料）&lt;/li&gt;&lt;li&gt;day（発送日数）&lt;/li&gt;&lt;li&gt;image（商品画像）&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
+                <mxCell id="13" value="&lt;ul&gt;&lt;li&gt;item_name&lt;/li&gt;&lt;li&gt;user （出品者）&lt;/li&gt;&lt;li&gt;price&lt;/li&gt;&lt;li&gt;category&lt;/li&gt;&lt;li&gt;overview（商品説明）&lt;/li&gt;&lt;li&gt;status（商品の状態）&lt;/li&gt;&lt;li&gt;city（発送元地域）&lt;/li&gt;&lt;li&gt;cgage（配送手数料）&lt;/li&gt;&lt;li&gt;delivery（発送日数）&lt;/li&gt;&lt;li&gt;image（商品画像）&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" vertex="1" parent="1">
                     <mxGeometry x="480" y="420" width="220" height="220" as="geometry"/>
                 </mxCell>
                 <mxCell id="47" style="edgeStyle=none;html=1;exitX=1;exitY=0.75;exitDx=0;exitDy=0;fontSize=20;startArrow=ERone;startFill=0;endArrow=ERmany;endFill=0;" edge="1" parent="1" source="14">


### PR DESCRIPTION
DBの設計。以下、各テーブルについて。

# what
usersテーブルの設計
# why
デバイスを利用したアカウントの作成と管理。閲覧するときの出品者の情報、または自分が出品する際、購入する際に、参照させる為。
またログインしていない時は、商品の出品及び購入ができないように設定にさせる為。


# what
itemsテーブル（商品出品）の設計
# why
自分が出品した、または他者が出品している商品を扱うため。商品ページ。
商品ページには、購入に関するデータは格納しないよう、あくまで商品の閲覧、または自分が出品した場合は、その商品の編集・削除。
一人のユーザーが別の商品を同時に複数出品することを想定した為、usersテーブルとは一対多の関係を仮定。


# what
buyersテーブル（商品購入）の設計
#why
購入者の情報、pay.jpを利用したトークン生成のページ。
購入した商品を、購入記録としてテーブルに保存。


# what
addressesテーブルの設計
# why
商品を購入した際に、どこの住所へ送るかを扱う為。購入者が同じでも毎回ひとつの住所に送るは限らない為、buyerテーブルとは一体多の関係を仮定。
郵便番号、都道府県などは別にして保存した方が、今後の実装で検索・参照など何かに使えるかと思い、分割しての保存の仕方を仮定。


# what
Purchase historiesテーブル（購入履歴）の設計
# why
自身のアカウントが何を購入したのか確認・参照・検索できるようにする為。
他者が購入した商品の履歴は見えないようにしなければならない。あくまで自分の購入した商品だけを参照できるように。
一人のユーザーに対して、多数の購入履歴が想定されるので、usersテーブルとは一対多の関係を仮定。
また、購入した商品ひとつに対して複数の履歴は持たないと想定し、buyersテーブルとは一対一の関係を仮定。
buyersテーブルで購入記録として保存したデータを参照することを想定し、itemsテーブルとは紐付けしない。itemsテーブルを利用しての参照だと、出品者側が商品ページを削除した際に閲覧できなくなると仮定。


ER図
【URL】https://gyazo.com/f9c3b753174a4b42fe42a925a3167fc0