### PR TITLE
Item detail

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: :index
+  before_action :authenticate_user!, except: [ :index, :show ]
 
   def index
     @items = Item.order("created_at DESC")
@@ -16,6 +16,10 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   # def edit

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
 
     <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id), method: :get do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,18 +16,19 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.charge.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+  <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+  <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
@@ -37,33 +38,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.overview %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.city.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,9 @@
   <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
+  <% if user_signed_in? && current_user.id != @item.user_id %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+  <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
@@ -104,7 +106,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href= '#' class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,21 +23,18 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+  <%# ログイン有無での条件分岐 %>
   <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
   <% end %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
   <% if user_signed_in? && current_user.id != @item.user_id %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
   <% end %>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+  <%# /ログイン有無での条件分岐 %>
 
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.overview %></span>
@@ -105,9 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href= '#' class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>


### PR DESCRIPTION
商品詳細表示の実装を致しました。レビューをお願い致します。

# what
商品詳細表示の実装

# why
・ログインの有無に関わらず閲覧可能に設定。
・商品一覧ページから、該当商品をクリックすると詳細ページに遷移。
・詳細情報のビューの設定。インスタンスを使用したデータの引き渡し。
・自分で出品した商品は編集・削除ボタンが表示するように。
・自分で出品した商品以外は、購入ボタンが表示。
・ログインしないと購入ボタンは表示されない。


# 以下、提出gyazo


## ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/bda2803995c45eb22a121500217faff3

## ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/7f688da0ce5ffd1087bfbda26d391242

## ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
```現在、購入機能はまだ実装していないため、提出Gyazoはありません。```

## ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/b1aa4ca1e3e30b8ae8f51fc37b822f37